### PR TITLE
Change CODEOWNER to @nsustain/core-dev team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # CODEOWNERS file is useful because this makes PR's to automatically
 # request review from the listed users.
 # ----------------------------------------------------------------------------
-* @soobinrho
+* @nsustain/core-dev


### PR DESCRIPTION
Instead of @soobinrho, automatic review requests will go to @Nsustain/core-dev team.